### PR TITLE
Fixes tmpdir

### DIFF
--- a/src/main/java/net/jgp/books/spark/ch10/x/utils/streaming/lib/StreamingUtils.java
+++ b/src/main/java/net/jgp/books/spark/ch10/x/utils/streaming/lib/StreamingUtils.java
@@ -39,7 +39,7 @@ public class StreamingUtils {
     if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
       this.inputDirectory = "C:\\TEMP\\";
     } else {
-      this.inputDirectory = System.getProperty("java.io.tmpdir");
+      this.inputDirectory = System.getProperty("java.io.tmpdir") + File.separator;
     }
     this.inputDirectory +=
         "streaming" + File.separator + "in" + File.separator;


### PR DESCRIPTION
Added a 'File.separator' to avoid wrong concatenation of the word 'streaming' with the name of the tmpdir in systems that doesn't starts with 'win'.